### PR TITLE
skip empty lines while reading GFF files

### DIFF
--- a/bioinfokit/analys.py
+++ b/bioinfokit/analys.py
@@ -1258,7 +1258,7 @@ class gff:
         cds_ct = 0
 
         for line in read_gff_file_cds:
-            if not line.startswith('#'):
+            if not line.startswith('#') and line.strip():
                 line = re.split('\s+', line.strip())
                 if line[2] == 'mRNA' or line[2] == 'transcript' or line[2] == trn_feature_name:
                     # attr = re.split(';', line[8])
@@ -1306,7 +1306,7 @@ class gff:
         ttr_i, cds_i, exon_i, ftr_i = dict(), dict(), dict(), dict()
 
         for line in read_gff_file:
-            if not line.startswith('#'):
+            if not line.startswith('#') and line.strip():
                 line = re.split('\s+', line.strip())
                 if line[2] == 'gene':
                     # attr = re.split(';', line[8])
@@ -1546,7 +1546,7 @@ class gff:
         read_gff_file = open(file, 'r')
         transcript_id = ''
         for line in read_gff_file:
-            if not line.startswith('#'):
+            if not line.startswith('#') and line.strip():
                 line = re.split('\t', line.strip())
                 if line[2]=='gene':
                     if 'ID=' in line[8]:
@@ -1689,7 +1689,7 @@ class lncrna:
         mrna_dict_1 = dict()
         line_num = 0
         for line in read_gff_file:
-            if not line.startswith('#'):
+            if not line.startswith('#') and line.strip():
                 line = re.split('\t', line.strip())
                 line_num += 1
                 line.extend([line_num])


### PR DESCRIPTION
I am proposing the addition of an if statement to skip empty lines in input GFF files before attempting to split them. While most GFF files would not require this change, this is useful for GFF files obtained from certain programs (example: GeneMarkS).

Attached is an excerpt from the GFF output from GeneMarkS : [trial_GFF_excerpt.txt](https://github.com/reneshbedre/bioinfokit/files/6523507/trial_GFF_excerpt.txt)

Without the if statement that is included in this pull request, the program tries to split the empty lines between gene entries and returns an error.