### PR TITLE
Limit dropna to named variables in ttest

### DIFF
--- a/bioinfokit/analys.py
+++ b/bioinfokit/analys.py
@@ -1029,11 +1029,11 @@ class stat:
     def ttest(self, df='dataframe', xfac=None, res=None, evar=True, alpha=0.05, test_type=None, mu=None):
         # drop NaN
         if res != None & xfac != None:
-            df = df.dropna(axis=1, subset = [xfac, res])
+            df = df.dropna(axis=0, subset = [xfac, res])
         elif res != None:
-            df = df.dropna(axis=1, subset = [res])
+            df = df.dropna(axis=0, subset = [res])
         elif xfac != None:
-            df = df.dropna(axis=1, subset = [xfac])
+            df = df.dropna(axis=0, subset = [xfac])
         if df.shape[0] < 2:
             raise Exception("Very few observations to run t-test")
         if alpha < 0 or alpha > 1:

--- a/bioinfokit/analys.py
+++ b/bioinfokit/analys.py
@@ -1028,7 +1028,12 @@ class stat:
 
     def ttest(self, df='dataframe', xfac=None, res=None, evar=True, alpha=0.05, test_type=None, mu=None):
         # drop NaN
-        df = df.dropna()
+        if res != None & xfac != None:
+            df = df.dropna(axis=1, subset = [xfac, res])
+        elif res != None:
+            df = df.dropna(axis=1, subset = [res])
+        elif xfac != None:
+            df = df.dropna(axis=1, subset = [xfac])
         if df.shape[0] < 2:
             raise Exception("Very few observations to run t-test")
         if alpha < 0 or alpha > 1:


### PR DESCRIPTION
rows are only dropped if they are nan for a named variable,
either res or xfac, in the ttest function. This ensures that rows
with data in res and xfac are not dropped simply because of nan in
other variables. This aligns output with ttest functions in scipy
and statsmodels.