### PR TITLE
resolve encoding problem in installing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 import bioinfokit
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding="UTF-8") as fh:
     long_description = fh.read()
 
 setup(name='bioinfokit',


### PR DESCRIPTION
When installing bioinfokit using pip and git, an encoding error occurs in the setip.py file